### PR TITLE
Added i18n support

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -5,6 +5,7 @@
     "Recent replies": "Recent Replies",
     "Replying to": "Replying to",
     "Replying to post by": "Replying to post by",
+    "Read more": "Read More",
     "Older": "Older",
     "Newer": "Newer",
     "Unsubscribe": "Unsubscribe",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,15 @@
+{
+    "Archive": "Archive",
+    "Categories": "Categories",
+    "Full post list": "Full Post List",
+    "Recent replies": "Recent Replies",
+    "Replying to": "Replying to",
+    "Replying to post by": "Replying to post by",
+    "Older": "Older",
+    "Newer": "Newer",
+    "Unsubscribe": "Unsubscribe",
+    "View in browser": "View in browser",
+    "Hosted by": "Hosted by",
+    "Powered by": "Powered by",
+    "Designed with love": "Designed with <span class=\"red\">♥</span> by"
+}

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -1,0 +1,15 @@
+{
+    "Archive": "Archivo",
+    "Categories": "Categorías",
+    "Full post list": "Lista completa de publicaciones",
+    "Recent replies": "Respuestas recientes",
+    "Replying to": "Respondiendo a",
+    "Replying to post by": "Respondiendo a la publicación de",
+    "Older": "Más antiguo",
+    "Newer": "Más reciente",
+    "Unsubscribe": "Darse de baja",
+    "View in browser": "Ver en el navegador",
+    "Hosted by": "Alojado por",
+    "Powered by": "Desarrollado por",
+    "Designed with love": "Diseñado con <span class=\"red\">♥</span> por"
+}

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -7,6 +7,7 @@
     "Replying to post by": "Respondiendo a la publicación de",
     "Older": "Más antiguo",
     "Newer": "Más reciente",
+    "Read more": "Leer más",
     "Unsubscribe": "Darse de baja",
     "View in browser": "Ver en el navegador",
     "Hosted by": "Alojado por",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -7,6 +7,7 @@
     "Replying to post by": "Répondre au post de",
     "Older": "Plus ancien",
     "Newer": "Plus récent",
+    "Read more": "Lire la suite",
     "Unsubscribe": "Se désabonner",
     "View in browser": "Voir dans le navigateur",
     "Hosted by": "Hébergé par",

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1,0 +1,15 @@
+{
+    "Archive": "Archives",
+    "Categories": "Catégories",
+    "Full post list": "Liste complète des articles",
+    "Recent replies": "Réponses récentes",
+    "Replying to": "Répondre à",
+    "Replying to post by": "Répondre au post de",
+    "Older": "Plus ancien",
+    "Newer": "Plus récent",
+    "Unsubscribe": "Se désabonner",
+    "View in browser": "Voir dans le navigateur",
+    "Hosted by": "Hébergé par",
+    "Powered by": "Propulsé par",
+    "Designed with love": "Conçu avec <span class=\"red\">♥</span> par"
+}

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -7,6 +7,7 @@
     "Replying to post by": "In risposta al post di",
     "Older": "Precedenti",
     "Newer": "Successivi",
+    "Read more": "Leggi di più",
     "Unsubscribe": "Disiscriviti",
     "View in browser": "Leggi nel browser",
     "Hosted by": "Ospitato da",

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -1,0 +1,15 @@
+{
+    "Archive": "Archivio",
+    "Categories": "Categorie",
+    "Full post list": "Lista completa degli articoli",
+    "Recent replies": "Risposte Recenti",
+    "Replying to": "In risposta a",
+    "Replying to post by": "In risposta al post di",
+    "Older": "Precedenti",
+    "Newer": "Successivi",
+    "Unsubscribe": "Disiscriviti",
+    "View in browser": "Leggi nel browser",
+    "Hosted by": "Ospitato da",
+    "Powered by": "Basato su",
+    "Designed with love": "Progettato con il <span class=\"red\">♥</span> da"
+}

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -1,0 +1,15 @@
+{
+    "Archive": "Arquivo",
+    "Categories": "Categorias",
+    "Full post list": "Lista completa de postagens",
+    "Recent replies": "Respostas recentes",
+    "Replying to": "Respondendo a",
+    "Replying to post by": "Respondendo à postagem de",
+    "Older": "Mais antigo",
+    "Newer": "Mais recente",
+    "Unsubscribe": "Cancelar inscrição",
+    "View in browser": "Ver no navegador",
+    "Hosted by": "Hospedado por",
+    "Powered by": "Supotado por",
+    "Designed with love": "Desenhado com <span class=\"red\">♥</span> por"
+}

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -7,6 +7,7 @@
     "Replying to post by": "Respondendo à postagem de",
     "Older": "Mais antigo",
     "Newer": "Mais recente",
+    "Read more": "Ler mais",
     "Unsubscribe": "Cancelar inscrição",
     "View in browser": "Ver no navegador",
     "Hosted by": "Hospedado por",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -7,6 +7,7 @@
     "Replying to post by": "Ответ на сообщение от",
     "Older": "Старее",
     "Newer": "Новее",
+    "Read more": "Подробнее",
     "Unsubscribe": "Отписаться",
     "View in browser": "Посмотреть в браузере",
     "Hosted by": "Хостинг предоставлен",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -1,0 +1,15 @@
+{
+    "Archive": "Архив",
+    "Categories": "Категории",
+    "Full post list": "Полный список сообщений",
+    "Recent replies": "Последние ответы",
+    "Replying to": "Ответ на",
+    "Replying to post by": "Ответ на сообщение от",
+    "Older": "Старее",
+    "Newer": "Новее",
+    "Unsubscribe": "Отписаться",
+    "View in browser": "Посмотреть в браузере",
+    "Hosted by": "Хостинг предоставлен",
+    "Powered by": "Работает на",
+    "Designed with love": "Сделано с <span class=\"red\">♥</span> компанией"
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ with .Site.Language }}{{ . }}{{ else }}en{{ end }}">
 
 {{ partial "head.html" . }}
 

--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -1,13 +1,13 @@
 {{ define "main" }}
 <div class="archive">
-	<h2 class="p-name post-title">Archive</h2>
+	<h2 class="p-name post-title">{{ T "Archive" }}</h2>
 	{{ if templates.Exists "partials/microhook-archive-lead.html" }}
 	{{ partial "microhook-archive-lead.html" . }}
 	{{ end }}
 	{{ $list := ($.Site.GetPage "taxonomyTerm" "categories").Pages }}
 	{{ if gt (len $list) 0 }}
 	<div class="archive-categories">
-		<h3>Categories</h3>
+		<h3>{{ T "Categories" }}</h3>
 		<div class="category-list">
 			{{ range $list }}
 			<a href="{{ .Permalink }}"><button>{{ .Title }}</button></a>
@@ -16,12 +16,12 @@
 	</div>
 	{{ end }}
 	<div class="full-archives h-feed">
-		<h3>Full Post List</h3>
+		<h3>{{ T "Full post list" }}</h3>
 		{{ $list := (where .Site.Pages "Type" "post") }}
 		{{ range $list }}
 
 		<p class="h-entry">
-			<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ .Date.Format "Jan 2, 2006" }}</span></a>:
+			<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ partial "dateformat/short" . }}</span></a>:
 			{{ if .Title }}
 			<span class="p-name"><b>{{ .Title }}</b></span>
 			{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -15,7 +15,7 @@
           {{ partial "microhook-post-list-byline.html" . }}
           {{ else }}
           <div class="post-date-wrapper">
-          <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "January 2, 2006" }}</time></a>
+          <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/long" . }}</time></a>
           </div>
           {{ end }}
           {{ if .Title }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -20,7 +20,7 @@
           {{ end }}
           {{ if .Title }}
               <h2 class="post-title p-name"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
-                  {{ if in .RawContent "<!--more-->" }}
+                  {{ if in .RawContent "<!--more-->" }}                        
                       <div class="p-summary">
                           {{ $splitContents := split .RawContent "<!--more-->" }}
                           {{ $summary := index $splitContents 0 }}
@@ -35,7 +35,7 @@
                               {{ end }}
                           </button></a></p>
                       </div>
-                  {{ else }}
+                  {{ else }}                  
                       <div class="e-content with-title">
                           {{ .Content }}
                       </div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -31,7 +31,7 @@
                               {{ if templates.Exists "partials/microhook-read-more-text.html" }}
                               {{ partial "microhook-read-more-text.html" . }}
                               {{ else }}
-                              Read More →
+                              {{ T "Read more" }} →
                               {{ end }}
                           </button></a></p>
                       </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,8 +9,8 @@
   <h2 class="p-name post-title">{{ .Title }}</h2>
   {{ end }}
 
-  {{ if .Params.reply_to_url }} <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Jan 2, 2006" }}</time> ∞</a>
-  <div class="reply-to"> Replying to: {{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">@{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}
+  {{ if .Params.reply_to_url }} <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/long" . }}</time> ∞</a>
+  <div class="reply-to"> {{ T "Replying to" }}: {{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">@{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}
 
   <article class="post-content">
     {{ .Content }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,7 +15,11 @@
             {{ partial "microhook-post-list-byline.html" . }}
             {{ else }}
             <div class="post-date-wrapper">
-            <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "January 2, 2006" }}</time></a>
+            <a href="{{ .Permalink }}" class="post-date u-url">
+                <time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">
+                    {{ partial "dateformat/long" . }}
+                </time>
+            </a>
             </div>
             {{ end }}
             {{ if .Title }}
@@ -62,12 +66,12 @@
 <div class="post-nav">
     {{ if $paginator.HasPrev }}
     <span class="prev">
-        <a href="{{ $paginator.Prev.URL }}" title="Previous Page"><button>← Newer</button></a>
+        <a href="{{ $paginator.Prev.URL }}" title="Previous Page"><button>← {{ T "Newer" }}</button></a>
     </span>
     {{ end }}
     {{ if $paginator.HasNext }}
     <span class="next">
-        <a href="{{ $paginator.Next.URL }}"><button>Older →</button></a>
+        <a href="{{ $paginator.Next.URL }}"><button>{{ T "Older" }} →</button></a>
     </span>
     {{ end }}
 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -35,7 +35,7 @@
                                 {{ if templates.Exists "partials/microhook-read-more-text.html" }}
                                 {{ partial "microhook-read-more-text.html" . }}
                                 {{ else }}
-                                Read More →
+                                {{ T "Read more" }} →
                                 {{ end }}
                             </button></a></p>
                         </div>

--- a/layouts/newsletter.html
+++ b/layouts/newsletter.html
@@ -55,7 +55,7 @@
 
 	{{ range .Pages }}
 	<div class="post">
-		<a href="{{ .Permalink }}" class="microblog_permalink">{{ .Date.Format "Jan 2, 2006" }} ↓</a>
+		<a href="{{ .Permalink }}" class="microblog_permalink">{{ partial "dateformat/short" . }} ↓</a>
 
 		{{ if .Title }}
 		<h3>{{ .Title }}</h3>
@@ -74,11 +74,11 @@
 
 	<div class="microblog_footer">
 
-		<a href="{{ .Footer.UnsubscribeURL }}">Unsubscribe</a> <span class="microblog_divider">|</span>
+		<a href="{{ .Footer.UnsubscribeURL }}">{{ T "Unsubscribe" }}</a> <span class="microblog_divider">|</span>
 
 		{{ if eq (len .Pages) 1 }}
 		{{ with index .Pages 0 }}
-		<a href="{{ .Permalink }}">View in browser</a> <span class="microblog_divider">|</span>
+		<a href="{{ .Permalink }}">{{ T "View in browser" }}</a> <span class="microblog_divider">|</span>
 		{{ end }}
 		{{ end }}
 

--- a/layouts/partials/dateformat/long.html
+++ b/layouts/partials/dateformat/long.html
@@ -1,0 +1,1 @@
+{{ time.Format (default "January 2, 2006" .Site.Params.dateFormatLong) .Date }}

--- a/layouts/partials/dateformat/short.html
+++ b/layouts/partials/dateformat/short.html
@@ -1,0 +1,1 @@
+{{ time.Format (default "Jan 2, 2006" .Site.Params.dateFormatShort) .Date }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
     {{ else }}
     <p class="custom_footer">{{ partial "custom_footer.html" . }}</p>
     {{ end }}
-    <p class="attribution custom_footer">Hosted by <a href="https://micro.blog">Micro.blog</a>. Powered by <a href="https://sumo.micro.blog">Sumo Theme</a>. Designed with <span class="red">♥</span> by <a href="https://www.mattlangford.com">Matt Langford</a>.</p>
+    <p class="attribution custom_footer">{{ T "Hosted by" }} <a href="https://micro.blog">Micro.blog</a>. {{ T "Powered by" }} <a href="https://sumo.micro.blog">Sumo Theme</a>. {{ T "Designed with love" | safeHTML }} <a href="https://www.mattlangford.com">Matt Langford</a>.</p>
   </div>
 
 </footer>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -11,7 +11,7 @@
     {{ partial "microhook-post-byline.html" . }}
     {{ else }}
     <div class="post-date-wrapper">
-    <time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "January 2, 2006" }}</time>
+    <time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/long" . }}</time>
     </div>
     {{ end }}
     {{ if .Title }}

--- a/layouts/section/replies.html
+++ b/layouts/section/replies.html
@@ -5,7 +5,7 @@
 	{{ partial "microhook-before-replies.html" . }}
 	{{ end }}
 
-	<h2 class="replies-title">Recent Replies</h2>
+	<h2 class="replies-title">{{ T "Recent replies" }}</h2>
 	<div class="post-list">
 		{{ if .Site.Params.paginate_replies }}
 		{{ $paginator := .Paginate (where .Data.Pages.ByDate.Reverse "Type" "reply") }}
@@ -16,10 +16,10 @@
 			<h1 class="p-name post-title"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h1>
 				{{ end }}
 
-				<a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Jan 2, 2006" }}</time> ∞</a>
+				<a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/short" . }}</time> ∞</a>
 
 				{{ if .Params.reply_to_url }}
-				<div class="reply-to"> Replying to: {{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">@{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}
+				<div class="reply-to"> {{ T "Replying to" }}: {{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">@{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}
 
 				<div class="e-content">
 					{{ .Content }}
@@ -34,10 +34,10 @@
 			<h2 class="p-name"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
 			{{ end }}
 			<div class="post-date-wrapper">
-				<time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
+				<time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/short" . }}</time>
 			</div>
 			{{ if .Params.reply_to_url }}
-			<div class="reply-to">{{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">Replying to post by @{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}
+			<div class="reply-to">{{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ T "Replying to post by" }} @{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}
 
 			<div class="e-content">
 				{{ .Content }}


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support for the theme. With this enhancement, you can display messages and dates in the desired language by simply changing the `defaultContentLanguage` parameter in the `config.json` file.

Some example screenshots taken from my local development computer:

**Spanish translation for the 'Archive' page**

<img width="792" alt="Screenshot 2025-01-12 alle 18 55 11" src="https://github.com/user-attachments/assets/8952ca00-438d-4074-ae70-14faef98377f" />

**Russian translation for the 'Archive' page**

<img width="785" alt="Screenshot 2025-01-12 alle 18 54 24" src="https://github.com/user-attachments/assets/a7aeda9d-af2f-47fe-bd48-019f9f642f50" />


### Available Translations

The currently available translations can be found in the `i18n` folder and include the following languages:

- English
- French
- Spanish
- Portuguese
- Italian
- Russian

The Italian translation was manually curated, while the English version was created by transcribing the site's old texts. The other translations were automatically generated using ChatGPT and therefore might not be completely accurate.

### How to Add a New Translation

To add a new language translation, simply create a JSON file with the two-character international code for the language in the `i18n` folder. For example, to create a translation in Swedish, name the file `i18n/sv.json`.

Inside the new JSON file, just copy and paste the content of the `i18n/en.json` file and translate the values into the desired language.

### Date Format

To customize the date format, you can use the `Params.dateFormatLong` and `Params.dateFormatShort` parameters in the `config.json` file. For example:

```json
{
    "params": {
        "dateFormatShort": "2 Jan 2006",
        "dateFormatLong": "2 January 2006"
    }
}
```

If none of those two parameters are provided by the user, the default date format will be "Janary 2, 2006" and "Jan 2, 2006".

### Additional Notes

Feel free to rename the variables in the configuration to suit your work style and conventions.