### PR TITLE
Custom Social Card Image Support

### DIFF
--- a/layouts/partials/custom/socialcardimage.html
+++ b/layouts/partials/custom/socialcardimage.html
@@ -1,8 +1,7 @@
 {{- if .Site.Params.socialCardImage -}}
-{{- $socialCardImage := .Site.Params.socialCardImage | absURL -}}
+    {{- $socialCardImage := .Site.Params.socialCardImage | relURL -}}
+{{- else -}}
+    {{- $socialCardImage := .Site.Author.avatar | relURL -}}
+{{- end -}}
 <meta name="twitter:image" content="{{ $socialCardImage }}">
 <meta property="og:image" content="{{ $socialCardImage }}">
-{{- else -}}
-<meta name="twitter:image" content="{{ .Site.Author.avatar }}">
-<meta property="og:image" content="{{ .Site.Author.avatar }}">
-{{- end -}}

--- a/layouts/partials/custom/socialcardimage.html
+++ b/layouts/partials/custom/socialcardimage.html
@@ -1,7 +1,8 @@
+{{- $socialCardImage := "" -}}
 {{- if .Site.Params.socialCardImage -}}
-    {{- $socialCardImage := .Site.Params.socialCardImage | relURL -}}
+    {{- $socialCardImage = .Site.Params.socialCardImage | relURL -}}
 {{- else -}}
-    {{- $socialCardImage := .Site.Author.avatar | relURL -}}
+    {{- $socialCardImage = .Site.Author.avatar | relURL -}}
 {{- end -}}
 <meta name="twitter:image" content="{{ $socialCardImage }}">
 <meta property="og:image" content="{{ $socialCardImage }}">

--- a/layouts/partials/custom/socialcardimage.html
+++ b/layouts/partials/custom/socialcardimage.html
@@ -1,0 +1,8 @@
+{{- if .Site.Params.socialCardImage -}}
+{{- $socialCardImage := .Site.Params.socialCardImage | absURL -}}
+<meta name="twitter:image" content="{{ $socialCardImage }}">
+<meta property="og:image" content="{{ $socialCardImage }}">
+{{- else -}}
+<meta name="twitter:image" content="{{ .Site.Author.avatar }}">
+<meta property="og:image" content="{{ .Site.Author.avatar }}">
+{{- end -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,8 +14,13 @@
   <meta name="twitter:description" content="{{ .Site.Params.itunes_description | truncate 125 }}">
   <meta name="og:description" content="{{ .Site.Params.itunes_description | truncate 60 }}">
   <meta name="description" content="{{ .Site.Params.itunes_description }}">
+  {{ if .Site.params.socialCardImage }}
+  <meta name="twitter:image" content="{{ .Site.params.socialCardImage }}">
+  <meta property="og:image" content="{{ .Site.params.socialCardImage }}">
+  {{ else }}
   <meta name="twitter:image" content="{{ .Site.Author.avatar }}">
   <meta property="og:image" content="{{ .Site.Author.avatar }}">
+  {{ end }}
   {{ else }}
   <meta name="twitter:description" content="{{ .Summary | truncate 60 }}">
   <meta name="og:description" content="{{ .Summary | truncate 60 }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,13 +14,7 @@
   <meta name="twitter:description" content="{{ .Site.Params.itunes_description | truncate 125 }}">
   <meta name="og:description" content="{{ .Site.Params.itunes_description | truncate 60 }}">
   <meta name="description" content="{{ .Site.Params.itunes_description }}">
-  {{ if .Site.Params.socialCardImage }}
-  <meta name="twitter:image" content="{{ .Site.Params.socialCardImage }}">
-  <meta property="og:image" content="{{ .Site.Params.socialCardImage }}">
-  {{ else }}
-  <meta name="twitter:image" content="{{ .Site.Author.avatar }}">
-  <meta property="og:image" content="{{ .Site.Author.avatar }}">
-  {{ end }}
+  {{ partial "custom/socialcardimage" . }}
   {{ else }}
   <meta name="twitter:description" content="{{ .Summary | truncate 60 }}">
   <meta name="og:description" content="{{ .Summary | truncate 60 }}">
@@ -29,6 +23,8 @@
   {{ range .Params.photos }}
   <meta name="twitter:image" content="{{ . }}">
   <meta property="og:image" content="{{ . }}">
+  {{ else }}
+  {{ partial "custom/socialcardimage" . }}
   {{ end }}
   <title>{{ block "title" . }}{{ if .IsHome }}{{ .Site.Title }}{{ else if .Title }}{{ .Title }} | {{ .Site.Title }}{{ else }}{{ delimit (split .Summary " " | first 5) " " }} … | {{ .Site.Title }}{{ end }}{{ end }}</title>
   <link rel="canonical" href="{{ .Permalink }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,42 +3,40 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="twitter:card" content="summary">
-  {{ with .Title }}
-  <meta name="twitter:title" content="{{ . }}">
-  <meta property="og:title" content="{{ . }}">
+  {{- with .Title -}}
+    <meta name="twitter:title" content="{{ . }}">
+    <meta property="og:title" content="{{ . }}">
   {{ else }}
-  <meta name="twitter:title" content="{{ .Site.Title }}">
-  <meta property="og:title" content="{{ .Site.Title }}">
+    <meta name="twitter:title" content="{{ .Site.Title }}">
+    <meta property="og:title" content="{{ .Site.Title }}">
   {{ end }}
   {{ if .IsHome }}
-  <meta name="twitter:description" content="{{ .Site.Params.itunes_description | truncate 125 }}">
-  <meta name="og:description" content="{{ .Site.Params.itunes_description | truncate 60 }}">
-  <meta name="description" content="{{ .Site.Params.itunes_description }}">
-  {{ partial "custom/socialcardimage" . }}
+    <meta name="twitter:description" content="{{ .Site.Params.itunes_description | truncate 125 }}">
+    <meta name="og:description" content="{{ .Site.Params.itunes_description | truncate 60 }}">
+    <meta name="description" content="{{ .Site.Params.itunes_description }}">
+    {{ partial "custom/socialcardimage" . }}
   {{ else }}
-  <meta name="twitter:description" content="{{ .Summary | truncate 60 }}">
-  <meta name="og:description" content="{{ .Summary | truncate 60 }}">
-  <meta name="description" content="{{ .Summary }}">
-  {{ end }}
-  {{ range .Params.photos }}
-  <meta name="twitter:image" content="{{ . }}">
-  <meta property="og:image" content="{{ . }}">
-  {{ else }}
-  {{ partial "custom/socialcardimage" $ }}
-  {{ end }}
+    <meta name="twitter:description" content="{{ .Summary | truncate 60 }}">
+    <meta name="og:description" content="{{ .Summary | truncate 60 }}">
+    <meta name="description" content="{{ .Summary }}">
+  {{- end -}}
+  {{- range .Params.photos -}}
+    <meta name="twitter:image" content="{{ . }}">
+    <meta property="og:image" content="{{ . }}">      
+  {{- end -}}
   <title>{{ block "title" . }}{{ if .IsHome }}{{ .Site.Title }}{{ else if .Title }}{{ .Title }} | {{ .Site.Title }}{{ else }}{{ delimit (split .Summary " " | first 5) " " }} … | {{ .Site.Title }}{{ end }}{{ end }}</title>
   <link rel="canonical" href="{{ .Permalink }}">
   {{ if templates.Exists "partials/microhook-uncss.html" }}
-  {{ partial "microhook-uncss.html" . }}
+    {{ partial "microhook-uncss.html" . }}
   {{ else }}
-  <link rel="stylesheet" href="{{ "css/main.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
+    <link rel="stylesheet" href="{{ "css/main.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
   {{ end }}
   {{ if templates.Exists "partials/microhook-unfontawesome.html" }}
-  {{ else }}
-  <link rel="stylesheet" href="{{ "css/all.min.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
-  {{ end }}
+  {{- else -}}
+    <link rel="stylesheet" href="{{ "css/all.min.css" | relURL }}?{{ .Site.Params.theme_seconds }}">
+  {{- end -}}
   {{ partial "microblog_head.html" . }}
-  {{ if templates.Exists "partials/microhook-head.html" }}
-  {{ partial "microhook-head.html" . }}
+  {{- if templates.Exists "partials/microhook-head.html" -}}
+    {{ partial "microhook-head.html" . }}
   {{ end }}
 </head>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,9 +14,9 @@
   <meta name="twitter:description" content="{{ .Site.Params.itunes_description | truncate 125 }}">
   <meta name="og:description" content="{{ .Site.Params.itunes_description | truncate 60 }}">
   <meta name="description" content="{{ .Site.Params.itunes_description }}">
-  {{ if .Site.params.socialCardImage }}
-  <meta name="twitter:image" content="{{ .Site.params.socialCardImage }}">
-  <meta property="og:image" content="{{ .Site.params.socialCardImage }}">
+  {{ if .Site.Params.socialCardImage }}
+  <meta name="twitter:image" content="{{ .Site.Params.socialCardImage }}">
+  <meta property="og:image" content="{{ .Site.Params.socialCardImage }}">
   {{ else }}
   <meta name="twitter:image" content="{{ .Site.Author.avatar }}">
   <meta property="og:image" content="{{ .Site.Author.avatar }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,7 +24,7 @@
   <meta name="twitter:image" content="{{ . }}">
   <meta property="og:image" content="{{ . }}">
   {{ else }}
-  {{ partial "custom/socialcardimage" . }}
+  {{ partial "custom/socialcardimage" $ }}
   {{ end }}
   <title>{{ block "title" . }}{{ if .IsHome }}{{ .Site.Title }}{{ else if .Title }}{{ .Title }} | {{ .Site.Title }}{{ else }}{{ delimit (split .Summary " " | first 5) " " }} … | {{ .Site.Title }}{{ end }}{{ end }}</title>
   <link rel="canonical" href="{{ .Permalink }}">

--- a/plugin.json
+++ b/plugin.json
@@ -22,7 +22,7 @@
 		"type": "string"
     },
 	{
-		"field": "params.cardImage",
+		"field": "params.socialCardImage",
 		"label": "Social Card Image",
 		"placeholder": "Relative URL for FB/X card (default: your avatar)",
 		"type": "string"

--- a/plugin.json
+++ b/plugin.json
@@ -1,37 +1,5 @@
 {
 	"version": "1.1.0",
 	"title": "Sumo Theme",
-	"description": "Sumo Theme is a powerful and opinionated theme available only for Micro.blog. Visit sumo.micro.blog for documentation and demos. Follow @mtt on Micro.blog.",
-	"fields": [
-    {
-    	"field": "defaultContentLanguage",
-    	"label": "Default Content Language",
-    	"placeholder": "options: it, en, fr, pt, es, ru; default: en",
-		"type": "string"
-    },	
-    {
-    	"field": "params.dateFormatShort",
-    	"label": "Short Date Format",
-		"placeholder": "Jan 2, 2006",
-		"type": "string"
-    },
-	{
-    	"field": "params.dateFormatLong",
-    	"label": "Long Date Format",
-		"placeholder": "January 2, 2006",
-		"type": "string"
-    },
-	{
-		"field": "params.socialCardImage",
-		"label": "Social Card Image",
-		"placeholder": "Relative URL for FB/X card (default: your avatar)",
-		"type": "string"
-	},
-	{
-    	"field": "paginate",
-    	"label": "Number of items shown per page",
-		"placeholder": 20,
-    	"type": "integer"
-    }
-	]
+	"description": "Sumo Theme is a powerful and opinionated theme available only for Micro.blog. Visit sumo.micro.blog for documentation and demos. Follow @mtt on Micro.blog."
 }

--- a/plugin.json
+++ b/plugin.json
@@ -29,7 +29,7 @@
 	},
 	{
     	"field": "paginate",
-    	"label": "Number of items shown per page in a paginated list",
+    	"label": "Number of items shown per page",
 		"placeholder": 20,
     	"type": "integer"
     }

--- a/plugin.json
+++ b/plugin.json
@@ -6,26 +6,32 @@
     {
     	"field": "defaultContentLanguage",
     	"label": "Default Content Language",
-    	"placeholder": "en",
+    	"placeholder": "options: it, en, fr, pt, es, ru; default: en",
 		"type": "string"
-    },
-	{
-    	"field": "paginate",
-    	"label": "Paginate",
-		"placeholder": 20,
-    	"type": "integer"
-    },
+    },	
     {
     	"field": "params.dateFormatShort",
-    	"label": "Date Format (Short)",
+    	"label": "Short Date Format",
 		"placeholder": "Jan 2, 2006",
 		"type": "string"
     },
 	{
     	"field": "params.dateFormatLong",
-    	"label": "Date Format (Long)",
+    	"label": "Long Date Format",
 		"placeholder": "January 2, 2006",
 		"type": "string"
+    },
+	{
+		"field": "params.cardImage",
+		"label": "Social Card Image",
+		"placeholder": "Relative URL for FB/X card (default: your avatar)",
+		"type": "string"
+	},
+	{
+    	"field": "paginate",
+    	"label": "Number of items shown per page in a paginated list",
+		"placeholder": 20,
+    	"type": "integer"
     }
 	]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,31 @@
 {
 	"version": "1.1.0",
 	"title": "Sumo Theme",
-	"description": "Sumo Theme is a powerful and opinionated theme available only for Micro.blog. Visit sumo.micro.blog for documentation and demos. Follow @mtt on Micro.blog."
+	"description": "Sumo Theme is a powerful and opinionated theme available only for Micro.blog. Visit sumo.micro.blog for documentation and demos. Follow @mtt on Micro.blog.",
+	"fields": [
+    {
+    	"field": "defaultContentLanguage",
+    	"label": "Default Content Language",
+    	"placeholder": "en",
+		"type": "string"
+    },
+	{
+    	"field": "paginate",
+    	"label": "Paginate",
+		"placeholder": 20,
+    	"type": "integer"
+    },
+    {
+    	"field": "params.dateFormatShort",
+    	"label": "Date Format (Short)",
+		"placeholder": "Jan 2, 2006",
+		"type": "string"
+    },
+	{
+    	"field": "params.dateFormatLong",
+    	"label": "Date Format (Long)",
+		"placeholder": "January 2, 2006",
+		"type": "string"
+    }
+	]
 }


### PR DESCRIPTION
## Summary  

Previously, the `twitter:image` and `og:image` meta tags in the `<head>` section of the homepage always used the user's **Micro.blog avatar** as the thumbnail image. However, since some **Micro.blog users can have multiple sites**, it didn't make sense for all of them to share the same profile image IMHO.

This update introduces a new **`socialCardImage`** parameter under `params` in the site configuration. If set, this custom image is used instead of the avatar.  

## Implementation Details  

- If `.Site.Params.socialCardImage` is defined, it is used for the meta tags.  
- Otherwise, the site falls back to `.Site.Author.avatar`.  
- The value is processed with `relURL` to ensure proper path handling.  

## Example Usage (config.json)  

```json
{
    "params": {
        "socialCardImage": "/images/logo_twitter.png"
    }
}
```

### NOTE : Since English is not my native language, I named the parameter socialCardImage because it seemed like a clear and descriptive name. However, feel free to change it if you think a more appropriate name would be better.