### PR TITLE
Archive categories sorting

### DIFF
--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -4,7 +4,7 @@
 	{{ if templates.Exists "partials/microhook-archive-lead.html" }}
 	{{ partial "microhook-archive-lead.html" . }}
 	{{ end }}
-	{{ $list := ($.Site.GetPage "taxonomyTerm" "categories").Pages }}
+	{{ $list := sort ($.Site.GetPage "taxonomyTerm" "categories").Pages "Title" }}	
 	{{ if gt (len $list) 0 }}
 	<div class="archive-categories">
 		<h3>{{ T "Categories" }}</h3>


### PR DESCRIPTION
There has been a problem in most themes for a while that the categories list is shown in essentially a random order on the Archive page. I think we should explicitly sort this alphabetically now. This PR takes the collection and calls `sort` on it.