### PR TITLE
Remove <button> as a descendant of <a>

### DIFF
--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -10,7 +10,7 @@
 		<h3>{{ T "Categories" }}</h3>
 		<div class="category-list">
 			{{ range $list }}
-			<a href="{{ .Permalink }}"><button>{{ .Title }}</button></a>
+			<a class="button" href="{{ .Permalink }}">{{ .Title }}</a>
 			{{ end }}
 		</div>
 	</div>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -27,13 +27,13 @@
                           {{ $summary := replaceRE "\\[\\^.*?\\]" "" $summary }}
                           {{ $summary := replaceRE "\\n\\[\\^.*?\\]:.*" "" $summary }}
                           <p>{{ $summary | markdownify }}</p>
-                          <p><a class="read-more" href="{{ .Permalink }}"><button>
+                          <p><a class="button read-more" href="{{ .Permalink }}">
                               {{ if templates.Exists "partials/microhook-read-more-text.html" }}
                               {{ partial "microhook-read-more-text.html" . }}
                               {{ else }}
                               {{ T "Read more" }} →
                               {{ end }}
-                          </button></a></p>
+                          </a></p>
                       </div>
                   {{ else if .Params.custom_summary }}
                   <div class="p-summary">
@@ -63,12 +63,12 @@
 <div class="post-nav">
     {{ if $paginator.HasPrev }}
     <span class="prev">
-        <a href="{{ $paginator.Prev.URL }}" title="Previous Page"><button>← Newer</button></a>
+        <a class="button" href="{{ $paginator.Prev.URL }}" title="Previous Page">← Newer</a>
     </span>
     {{ end }}
     {{ if $paginator.HasNext }}
     <span class="next">
-        <a href="{{ $paginator.Next.URL }}"><button>Older →</button></a>
+        <a class="button" href="{{ $paginator.Next.URL }}">Older →</a>
     </span>
     {{ end }}
 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,13 +31,13 @@
                             {{ $summary := replaceRE "\\[\\^.*?\\]" "" $summary }}
                             {{ $summary := replaceRE "\\n\\[\\^.*?\\]:.*" "" $summary }}
                             <p>{{ $summary | markdownify }}</p>
-                            <p><a class="read-more" href="{{ .Permalink }}"><button>
+                            <p><a class="button read-more" href="{{ .Permalink }}">
                                 {{ if templates.Exists "partials/microhook-read-more-text.html" }}
                                 {{ partial "microhook-read-more-text.html" . }}
                                 {{ else }}
                                 {{ T "Read more" }} →
                                 {{ end }}
-                            </button></a></p>
+                            </a></p>
                         </div>
                     {{ else if .Params.custom_summary }}
                         <div class="p-summary">
@@ -70,12 +70,12 @@
 <div class="post-nav">
     {{ if $paginator.HasPrev }}
     <span class="prev">
-        <a href="{{ $paginator.Prev.URL }}" title="Previous Page"><button>← {{ T "Newer" }}</button></a>
+        <a class="button" href="{{ $paginator.Prev.URL }}" title="Previous Page">← {{ T "Newer" }}</a>
     </span>
     {{ end }}
     {{ if $paginator.HasNext }}
     <span class="next">
-        <a href="{{ $paginator.Next.URL }}"><button>{{ T "Older" }} →</button></a>
+        <a class="button" href="{{ $paginator.Next.URL }}">{{ T "Older" }} →</a>
     </span>
     {{ end }}
 </div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -370,7 +370,7 @@ pre {
 	border: none;
 }
 
-button, .conversation-on-mb, .reply-on-mastodon, .reply-by-email, input:is([type="button"]), [type="submit"], [type="reset"]:disabled, input[type=search], input[type=email], input[type=text] {
+a.button, button, .conversation-on-mb, .reply-on-mastodon, .reply-by-email, input:is([type="button"]), [type="submit"], [type="reset"]:disabled, input[type=search], input[type=email], input[type=text] {
 	border: 1px solid var(--button-border);
 	background-color: var(--button-background);
 	color: var(--button-text);
@@ -384,7 +384,7 @@ button, .conversation-on-mb, .reply-on-mastodon, .reply-by-email, input:is([type
 	white-space: nowrap;
 }
 
-button:hover, .conversation-on-mb:hover, .reply-on-mastodon:hover, .reply-by-email:hover, input:is([type="button"]):hover, [type="submit"]:hover, [type="reset"]:disabled:hover {
+a.button:hover, button:hover, .conversation-on-mb:hover, .reply-on-mastodon:hover, .reply-by-email:hover, input:is([type="button"]):hover, [type="submit"]:hover, [type="reset"]:disabled:hover {
 	border-color: var(--button-border-hover);
 	background-color: var(--button-background-hover);
 	color: var(--button-text-hover);
@@ -398,14 +398,6 @@ button.did_select {
 	background-color: var(--button-background-hover);
 	cursor: not-allowed;
 	color: var(--button-text-hover);
-}
-
-a.button {
-	border-bottom: none;
-}
-
-.page-content a:has(button) {
-	border-bottom: none; /* Remove bottom border from <a> containing <button> */
 }
 
 .page-content p:has(video), .page-content p:has(iframe) {


### PR DESCRIPTION
It’s not valid HTML to have `<button>` be a descendant of `<a>`, so this removes instances of that and uses the `.button` class on `<a>` to provide the same styling.

You can see these changes live on my blog:

- The category links on this page: https://me.chasen.dev/archive/
- The Newer and Older links at the bottom of this page: https://me.chasen.dev/page/2/
- The “Read More” link under my Madrid post on this page: https://me.chasen.dev

The one thing I was unsure about was using `.button` as the class name—it doesn’t look like it was being used anywhere else, and seems like a good name to use. I’d be happy to change it if you have a better idea.

---

This is my first PR in this repo, and I hope contributions like this are welcome. There are a few improvements I’d like to make to the theme, and I’d love to contribute them upstream. I know maintaining an open source repo is work, so if there’s anything I can do to make things easier, or if you aren’t open to contributions, please let me know.