### PR TITLE
Fix invalid datetime format and replace <span> with <time> for published dates

### DIFF
--- a/layouts/_default/list.archivehtml.html
+++ b/layouts/_default/list.archivehtml.html
@@ -21,7 +21,7 @@
 		{{ range $list }}
 
 		<p class="h-entry">
-			<a href="{{ .Permalink }}" class="u-url"><span class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ partial "dateformat/short" . }}</span></a>:
+			<a href="{{ .Permalink }}" class="u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-0700" }}">{{ partial "dateformat/short" . }}</time></a>:
 			{{ if .Title }}
 			<span class="p-name"><b>{{ .Title }}</b></span>
 			{{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -15,7 +15,7 @@
           {{ partial "microhook-post-list-byline.html" . }}
           {{ else }}
           <div class="post-date-wrapper">
-          <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/long" . }}</time></a>
+          <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-07:00" }}">{{ partial "dateformat/long" . }}</time></a>
           </div>
           {{ end }}
           {{ if .Title }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,7 +9,7 @@
   <h2 class="p-name post-title">{{ .Title }}</h2>
   {{ end }}
 
-  {{ if .Params.reply_to_url }} <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/long" . }}</time> ∞</a>
+  {{ if .Params.reply_to_url }} <a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-07:00" }}">{{ partial "dateformat/long" . }}</time> ∞</a>
   <div class="reply-to"> {{ T "Replying to" }}: {{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">@{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}
 
   <article class="post-content">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -16,7 +16,7 @@
             {{ else }}
             <div class="post-date-wrapper">
             <a href="{{ .Permalink }}" class="post-date u-url">
-                <time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">
+                <time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-07:00" }}">
                     {{ partial "dateformat/long" . }}
                 </time>
             </a>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -11,7 +11,7 @@
     {{ partial "microhook-post-byline.html" . }}
     {{ else }}
     <div class="post-date-wrapper">
-    <time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/long" . }}</time>
+    <time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-07:00" }}">{{ partial "dateformat/long" . }}</time>
     </div>
     {{ end }}
     {{ if .Title }}

--- a/layouts/section/replies.html
+++ b/layouts/section/replies.html
@@ -15,7 +15,7 @@
 			<h1 class="p-name post-title"><a class="post-title" href="{{ .Permalink }}">{{ .Title }}</a></h1>
 				{{ end }}
 
-				<a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/short" . }}</time> ∞</a>
+				<a href="{{ .Permalink }}" class="post-date u-url"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-07:00" }}">{{ partial "dateformat/short" . }}</time> ∞</a>
 
 				{{ if .Params.reply_to_url }}
 				<div class="reply-to"> {{ T "Replying to" }}: {{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">@{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}
@@ -33,7 +33,7 @@
 			<h2 class="p-name"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
 			{{ end }}
 			<div class="post-date-wrapper">
-				<time class="dt-published" datetime="{{ .Date.Format "2006-01-02 15:04:05 -0700" }}">{{ partial "dateformat/short" . }}</time>
+				<time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-07:00" }}">{{ partial "dateformat/short" . }}</time>
 			</div>
 			{{ if .Params.reply_to_url }}
 			<div class="reply-to">{{ if eq .Params.reply_to_hostname "micro.blog" }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ T "Replying to post by" }} @{{ .Params.reply_to_username }}</a> {{ else }} <a href="{{ .Params.reply_to_url }}" class="u-in-reply-to">{{ .Params.reply_to_hostname }}</a> {{ end }} </div> {{ end }}


### PR DESCRIPTION
- Updated `datetime` attribute to use valid ISO 8601 format (`T` separator and `-07:00` offset)
- Replaced a stray `<span>` with `<time>`

You can see the html validator complain about the format before the fix: https://validator.w3.org/nu/?doc=https%3A%2F%2Fsumo.micro.blog

My blog has my fork, so this validation error doesn’t show up: https://validator.w3.org/nu/?doc=https%3A%2F%2Fme.chasen.dev%2F