### PR TITLE
Move quoteback-component styles from inline HTML to main CSS file

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,12 +23,5 @@
   {{ if templates.Exists "partials/microhook-before-closing-body.html" }}
   {{ partial "microhook-before-closing-body.html" . }}
   {{ end }}
-  <style>
-    quoteback-component {
-      display: block;
-      padding-left: 20px;
-      padding-right: 20px;
-    }
-  </style>
 </body>
 </html>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -588,6 +588,12 @@ form.microblog_reply_form {
 	border-radius: 20px;
 }
 
+/* QUOTEBACK EMBEDS */
+quoteback-component {
+	display: block;
+	padding-left: 20px;
+	padding-right: 20px;
+}
 
 /* Tinylytics */
 


### PR DESCRIPTION
This change relocates the `quoteback-component` block styles from `layouts/_default/baseof.html` to `static/css/main.css` to keep styling in the stylesheet and remove a validation error from having it in the `<body>`.

This has a downside: If someone has used `microhook-uncss.html`, now this style won’t be defined for them. I think this is ok—the component still shows up, it just doesn’t have these nicer styles.

There’s an upside too: Now that these styles are in the `main.css`, they’re easier to override without `!important` in a user’s `custom.css`.

This change can be seen live here: https://web.chasen.dev/2025/06/18/one-of-the-things-i.html