### PR TITLE
Make the link/button transitions smoother

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -127,7 +127,7 @@ body {
 	padding: 0.5em 1em;
 	font-size: 0.9em;
 	font-weight: 500;
-	transition: background-color 0.1s ease-in;
+	transition: all 0.1s ease-in;
 }
 
 .site-header nav a:hover {
@@ -379,7 +379,7 @@ a.button, button, .conversation-on-mb, .reply-on-mastodon, .reply-by-email, inpu
 	font-size: 0.9em;
 	font-weight: 500;
 	cursor: pointer;
-	transition: background-color 0.1s ease-in;
+	transition: all 0.1s ease-in;
 	margin: 3px 0;
 	white-space: nowrap;
 	line-height: 2.66em;


### PR DESCRIPTION
This expands the animation when hovering over links and buttons so all the colors animate (not just the background color). This makes the transition look a little smoother.

It’s subtle, so I’m not sure if it’ll be obvious in these recordings. I’ve deployed this change in my custom theme, so it’s visible here: https://web.chasen.dev/subscribe/

### Before

https://github.com/user-attachments/assets/43dc3f06-ba5e-4bf9-afd1-8bf834e731c0

### After

https://github.com/user-attachments/assets/954899e6-dbcf-4b1a-be30-c92835fa1779