### PR TITLE
Improve the profile photo alt text

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
 	{{ if templates.Exists "partials/microhook-profile-photo.html" }}
 	{{ partial "microhook-profile-photo.html" . }}
 	{{ else }}
-	<a href="/"><img src="{{ .Site.Author.avatar }}" alt="{{ .Site.Title }} Profile Photo" class="profile_photo u-photo" width="80" height="80"></a>
+	<a href="/"><img src="{{ .Site.Author.avatar }}" alt="{{ .Site.Title }} homepage" class="profile_photo u-photo" width="80" height="80"></a>
 	{{ end }}
 	{{ if templates.Exists "partials/microhook-title.html" }}
 	{{ partial "microhook-title.html" . }}


### PR DESCRIPTION
A very minor change, but this improves the `alt` text for the link that goes back to the homepage.

This article has great advice: https://html5accessibility.com/stuff/2024/11/23/old-alt-text-advice/#a-link-or-button-containing-nothing-but-an-image

One of the examples is a logo that goes back to the homepage, in which the best `alt` text actually isn’t describing the image (because on a theme level, we have no idea what the image contains) but instead indicates where the user will go if they follow the link.