### PR TITLE
Support Hugo 0.158 and pass tests

### DIFF
--- a/layouts/newsletter_legacy.html
+++ b/layouts/newsletter_legacy.html
@@ -44,7 +44,7 @@
 </style>
 
 <div class="microblog_email">
-	<img src="{{ .Site.Author.avatar }}" width="80" height="80" alt="Profile icon" class="email-profile-photo">
+	<img src="{{ .Site.Params.author.avatar }}" width="80" height="80" alt="Profile icon" class="email-profile-photo">
 	<h2>{{ .Site.Title }}</h2>
 
 	{{ if gt (len .Intro) 0 }}

--- a/layouts/partials/custom/socialcardimage.html
+++ b/layouts/partials/custom/socialcardimage.html
@@ -2,7 +2,7 @@
 {{- if .Site.Params.socialCardImage -}}
     {{- $socialCardImage = .Site.Params.socialCardImage | relURL -}}
 {{- else -}}
-    {{- $socialCardImage = .Site.Author.avatar | relURL -}}
+    {{- $socialCardImage = .Site.Params.author.avatar | relURL -}}
 {{- end -}}
 <meta name="twitter:image" content="{{ $socialCardImage }}">
 <meta property="og:image" content="{{ $socialCardImage }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,7 +27,7 @@
       {{ partial "custom/socialcardimage" . }}
     {{- end -}}
   {{- end -}}
-  <title>{{ block "title" . }}{{ if .IsHome }}{{ .Site.Title }}{{ else if .Title }}{{ .Title }} | {{ .Site.Title }}{{ else }}{{ delimit (split .Summary " " | first 5) " " }} … | {{ .Site.Title }}{{ end }}{{ end }}</title>
+  <title>{{ block "title" . }}{{ if .IsHome }}{{ .Site.Title }}{{ else if .Title }}{{ .Title }} | {{ .Site.Title }}{{ else }}{{ delimit (split (.Summary | plainify | htmlUnescape) " " | first 5) " " }} … | {{ .Site.Title }}{{ end }}{{ end }}</title>
   <link rel="canonical" href="{{ .Permalink }}">
   {{ if templates.Exists "partials/microhook-uncss.html" }}
     {{ partial "microhook-uncss.html" . }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
 	{{ if templates.Exists "partials/microhook-profile-photo.html" }}
 	{{ partial "microhook-profile-photo.html" . }}
 	{{ else }}
-	<a href="/"><img src="{{ .Site.Author.avatar }}" alt="{{ .Site.Title }} homepage" class="profile_photo u-photo" width="80" height="80"></a>
+	<a href="/"><img src="{{ .Site.Params.author.avatar }}" alt="{{ .Site.Title }} homepage" class="profile_photo u-photo" width="80" height="80"></a>
 	{{ end }}
 	{{ if templates.Exists "partials/microhook-title.html" }}
 	{{ partial "microhook-title.html" . }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -11,7 +11,11 @@
     {{ partial "microhook-post-byline.html" . }}
     {{ else }}
     <div class="post-date-wrapper">
-    <time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-07:00" }}">{{ partial "dateformat/long" . }}</time>
+    <a href="{{ .Permalink }}" class="post-date u-url">
+      <time class="dt-published" datetime="{{ .Date.Format "2006-01-02T15:04:05-07:00" }}">
+        {{ partial "dateformat/long" . }}
+      </time>
+    </a>
     </div>
     {{ end }}
     {{ if .Title }}


### PR DESCRIPTION
Fixes `.Summary` and `.Site.Author`. More info here: https://github.com/microdotblog/theme-blank/pull/12.

Adds missing `u-url` microformat to post template to pass [tests](https://github.com/svendahlstrand/test-blog).

These changes have been tested locally on my machine, and confirmed working on Hugo 0.91 and 0.158.